### PR TITLE
refactor(api): move GeolocationController to Api namespace

### DIFF
--- a/app/Http/Controllers/Api/GeolocationController.php
+++ b/app/Http/Controllers/Api/GeolocationController.php
@@ -1,13 +1,15 @@
 <?php
 
-namespace App\Http\Controllers;
+namespace App\Http\Controllers\Api;
 
 use App\Http\Requests\GeolocationRequest;
-use App\Libraries\IpApi;
+use App\Http\Controllers\Controller;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Response;
 use Illuminate\Http\Request;
+use App\Libraries\IpApi;
 use Maxidev\Logger\TailLogger;
+
 
 class GeolocationController extends Controller
 {

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,12 +1,11 @@
 <?php
 
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Http\JsonResponse;
 use App\Http\Controllers\Api\LeadController;
 use App\Http\Controllers\Api\TrafficLogController;
 use App\Http\Controllers\Api\PostbackController;
-use App\Http\Controllers\GeolocationController;
+use App\Http\Controllers\Api\GeolocationController;
 
 Route::any('/health', function () {
   return new JsonResponse(['status' => 'ok']);


### PR DESCRIPTION
Move the GeolocationController to the Api namespace to maintain consistency with other API controllers. Also clean up unused imports in routes/api.php