### PR TITLE
fix: rename 'ignored' to 'processed' in payout reconciliation response

### DIFF
--- a/app/Http/Controllers/Api/PostbackController.php
+++ b/app/Http/Controllers/Api/PostbackController.php
@@ -47,7 +47,7 @@ class PostbackController extends Controller
       'data' => [
         'date' => $validated['date'],
         'created' => $result['created'],
-        'ignored' => $result['ignored'],
+        'processed' => $result['processed'],
       ],
     ]);
   }


### PR DESCRIPTION
The field name was updated to better reflect its actual purpose of tracking processed records rather than ignored ones.