### PR TITLE
feat: enhance date filtering in DatatableTrait for accurate UTC handling

### DIFF
--- a/app/Traits/DatatableTrait.php
+++ b/app/Traits/DatatableTrait.php
@@ -2,6 +2,7 @@
 
 namespace App\Traits;
 
+use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Database\Eloquent\Builder;
 
@@ -284,11 +285,11 @@ trait DatatableTrait
         break;
 
       case 'from_date':
-        $query->whereDate($column, '>=', $value);
+        $query->where($column, '>=', $this->normalizeDateBound($value, false));
         break;
 
       case 'to_date':
-        $query->whereDate($column, '<=', $value);
+        $query->where($column, '<=', $this->normalizeDateBound($value, true));
         break;
 
       case 'upper':
@@ -303,6 +304,36 @@ trait DatatableTrait
         }
         break;
     }
+  }
+
+  /**
+   * Normaliza un bound de fecha/datetime a wall-clock UTC ('Y-m-d H:i:s').
+   *
+   * Los filtros from_date/to_date comparan contra el timestamp completo de la
+   * columna (no DATE truncado), respetando hora y offset del valor recibido.
+   *
+   * - Valor date-only (YYYY-MM-DD): se expande a un bound inclusivo de dia
+   *   completo (00:00:00 para from, 23:59:59 para to), preservando la
+   *   semantica previa de whereDate para consumidores que mandan fecha pelada.
+   * - Valor full timestamp (ISO 8601 con offset/Z, ej. emitido por el
+   *   DateRangePicker): se parsea y convierte al instante UTC exacto.
+   *
+   * Se normaliza con Carbon a 'Y-m-d H:i:s' (en vez de pasar el ISO crudo)
+   * para que la comparacion sea correcta tanto en PostgreSQL (timestamptz)
+   * como en SQLite (columnas de texto en los tests).
+   *
+   * @param string $value Fecha o datetime entrante (date-only o ISO 8601)
+   * @param bool $isEnd True para el bound superior (to_date), false para from_date
+   *
+   * @return string Timestamp UTC en formato 'Y-m-d H:i:s'
+   */
+  private function normalizeDateBound(string $value, bool $isEnd): string
+  {
+    if (preg_match('/^\d{4}-\d{2}-\d{2}$/', $value)) {
+      $value .= $isEnd ? ' 23:59:59' : ' 00:00:00';
+    }
+
+    return Carbon::parse($value)->utc()->format('Y-m-d H:i:s');
   }
 
   /**

--- a/tests/Feature/Visitors/VisitorDateFilterTest.php
+++ b/tests/Feature/Visitors/VisitorDateFilterTest.php
@@ -1,0 +1,95 @@
+<?php
+
+use App\Models\TrafficLog;
+use App\Models\User;
+use Inertia\Testing\AssertableInertia;
+
+use function Pest\Laravel\actingAs;
+
+/**
+ * Crea un TrafficLog con un created_at UTC explicito.
+ *
+ * created_at no es fillable, por eso se setea via forceFill + saveQuietly
+ * para evitar que updateTimestamps lo sobreescriba.
+ */
+function trafficLogAt(string $utc): TrafficLog
+{
+  $log = TrafficLog::factory()->create();
+  $log->forceFill(['created_at' => $utc])->saveQuietly();
+
+  return $log->fresh();
+}
+
+beforeEach(function () {
+  $this->admin = User::factory()->create(['role' => 'admin']);
+});
+
+test('from_date filter respeta el instante UTC exacto, no la fecha truncada', function () {
+  // Bound: from_date = 2026-06-01T04:00:00.000Z (medianoche local UTC-4).
+  $before = trafficLogAt('2026-06-01 03:59:59'); // antes del bound -> EXCLUIDO
+  $boundary = trafficLogAt('2026-06-01 04:00:00'); // en el bound -> INCLUIDO
+  $after = trafficLogAt('2026-06-01 12:00:00'); // despues -> INCLUIDO
+
+  $response = actingAs($this->admin)->get(
+    route('visitors.index', [
+      'filters' => json_encode([['id' => 'from_date', 'value' => '2026-06-01T04:00:00.000Z']]),
+      'per_page' => 100,
+    ]),
+  );
+
+  $response->assertSuccessful();
+  $response->assertInertia(function (AssertableInertia $page) use ($before, $boundary, $after) {
+    $rows = collect($page->toArray()['props']['rows']['data'])->pluck('id');
+
+    expect($rows)->not->toContain($before->id);
+    expect($rows)->toContain($boundary->id);
+    expect($rows)->toContain($after->id);
+  });
+});
+
+test('from_date + to_date filtran por rango UTC completo', function () {
+  $before = trafficLogAt('2026-06-01 03:59:59'); // antes del from -> EXCLUIDO
+  $inRange = trafficLogAt('2026-06-01 10:00:00'); // dentro -> INCLUIDO
+  $after = trafficLogAt('2026-06-02 04:00:01'); // pasado el to -> EXCLUIDO
+
+  $response = actingAs($this->admin)->get(
+    route('visitors.index', [
+      'filters' => json_encode([
+        ['id' => 'from_date', 'value' => '2026-06-01T04:00:00.000Z'],
+        ['id' => 'to_date', 'value' => '2026-06-02T03:59:59.999Z'],
+      ]),
+      'per_page' => 100,
+    ]),
+  );
+
+  $response->assertSuccessful();
+  $response->assertInertia(function (AssertableInertia $page) use ($before, $inRange, $after) {
+    $rows = collect($page->toArray()['props']['rows']['data'])->pluck('id');
+
+    expect($rows)->not->toContain($before->id);
+    expect($rows)->toContain($inRange->id);
+    expect($rows)->not->toContain($after->id);
+  });
+});
+
+test('date-only sigue siendo bound inclusivo de dia completo', function () {
+  $startOfDay = trafficLogAt('2026-06-01 00:00:00'); // INCLUIDO (from = dia completo)
+  $endOfDay = trafficLogAt('2026-06-01 23:59:59'); // INCLUIDO (to = dia completo)
+  $nextDay = trafficLogAt('2026-06-02 00:00:00'); // EXCLUIDO
+
+  $response = actingAs($this->admin)->get(
+    route('visitors.index', [
+      'filters' => json_encode([['id' => 'from_date', 'value' => '2026-06-01'], ['id' => 'to_date', 'value' => '2026-06-01']]),
+      'per_page' => 100,
+    ]),
+  );
+
+  $response->assertSuccessful();
+  $response->assertInertia(function (AssertableInertia $page) use ($startOfDay, $endOfDay, $nextDay) {
+    $rows = collect($page->toArray()['props']['rows']['data'])->pluck('id');
+
+    expect($rows)->toContain($startOfDay->id);
+    expect($rows)->toContain($endOfDay->id);
+    expect($rows)->not->toContain($nextDay->id);
+  });
+});


### PR DESCRIPTION
Implements a new method, normalizeDateBound, to ensure that date filters (from_date and to_date) accurately compare against full timestamps in UTC, preserving the integrity of date-only inputs. This change improves the filtering logic to handle both date-only and full timestamp formats correctly. Additionally, introduces comprehensive tests to validate the new date filtering behavior, ensuring expected results for various date scenarios.