### PR TITLE
feat: implement global search for dispatch logs using traffic log click IDs

### DIFF
--- a/app/Http/Controllers/Logs/LeadDispatchLogController.php
+++ b/app/Http/Controllers/Logs/LeadDispatchLogController.php
@@ -13,6 +13,7 @@ use App\Models\LeadDispatch;
 use App\Models\PingResult;
 use App\Models\PostbackExecution;
 use App\Models\PostResult;
+use App\Models\TrafficLog;
 use App\Models\Workflow;
 use App\Jobs\PingPost\DispatchLeadJob;
 use App\Jobs\PingPost\RetryDispatchJob;
@@ -36,10 +37,16 @@ class LeadDispatchLogController extends Controller
     $originalSort = $request->input('sort', '');
     $query = $this->buildDispatchQuery($request);
 
+    // Global search is applied manually here because s10 (tracking platform click
+    // id) lives on traffic_logs, not lead_dispatches, so it can't go through the
+    // trait's base-column LIKE search. Passing an empty searchableColumns keeps the
+    // trait from double-applying it.
+    $this->applyDispatchSearch($query, trim((string) $request->input('search', '')));
+
     $table = $this->processDatatableQuery(
       query: $query,
       request: $request,
-      searchableColumns: ['fingerprint', 'dispatch_uuid', 'utm_source'],
+      searchableColumns: [],
       filterConfig: self::FILTER_CONFIG,
       allowedSort: self::ALLOWED_SORT,
       defaultSort: 'created_at:desc',
@@ -104,7 +111,7 @@ class LeadDispatchLogController extends Controller
   public function report(Request $request): StreamedResponse
   {
     $query = $this->buildDispatchQuery($request);
-    $this->applyGlobalSearch($query, $request->input('search', ''), ['fingerprint', 'dispatch_uuid', 'utm_source']);
+    $this->applyDispatchSearch($query, trim((string) $request->input('search', '')));
     $this->applyColumnFilters($query, json_decode($request->input('filters', '[]'), true) ?? [], self::FILTER_CONFIG);
 
     $delimiter = $request->input('os') === 'windows' ? ';' : ',';
@@ -290,6 +297,29 @@ class LeadDispatchLogController extends Controller
   ];
 
   private const ALLOWED_SORT = ['id', 'status', 'strategy_used', 'final_price', 'total_duration_ms', 'created_at', 'utm_source'];
+
+  /**
+   * Apply the dispatch global search as an OR group over the base columns plus a
+   * cross-table match on `traffic_logs.s10` (tracking platform click id) resolved
+   * by fingerprint. No-op when the search term is empty.
+   *
+   * Shared between index() and report() so both stay in sync.
+   */
+  private function applyDispatchSearch(\Illuminate\Database\Eloquent\Builder $query, string $search): void
+  {
+    if ($search === '') {
+      return;
+    }
+
+    $like = "%{$search}%";
+
+    $query->where(function ($w) use ($search, $like) {
+      $w->orWhere('fingerprint', 'like', $like)
+        ->orWhere('dispatch_uuid', 'like', $like)
+        ->orWhere('utm_source', 'like', $like)
+        ->orWhereIn('fingerprint', TrafficLog::query()->where('s10', $search)->select('fingerprint'));
+    });
+  }
 
   /**
    * Build the base dispatch query with filters and join-based sorts.

--- a/database/migrations/2026_06_01_221209_add_index_to_s10_on_traffic_logs_table.php
+++ b/database/migrations/2026_06_01_221209_add_index_to_s10_on_traffic_logs_table.php
@@ -1,0 +1,51 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+  /**
+   * Build/drop the index OUTSIDE a transaction so PostgreSQL can use
+   * CREATE INDEX CONCURRENTLY (which is illegal inside a transaction block).
+   */
+  public $withinTransaction = false;
+
+  /**
+   * Run the migrations.
+   *
+   * `traffic_logs` is a high-write ingestion table with millions of rows, so a
+   * plain blocking CREATE INDEX would lock out writes for the whole build. On
+   * PostgreSQL we build CONCURRENTLY to avoid blocking ingestion; SQLite (tests)
+   * has no CONCURRENTLY and is tiny, so the regular Blueprint index is fine.
+   */
+  public function up(): void
+  {
+    if (DB::connection()->getDriverName() === 'pgsql') {
+      DB::statement('CREATE INDEX CONCURRENTLY IF NOT EXISTS traffic_logs_s10_index ON traffic_logs (s10)');
+
+      return;
+    }
+
+    Schema::table('traffic_logs', function (Blueprint $table) {
+      $table->index('s10');
+    });
+  }
+
+  /**
+   * Reverse the migrations.
+   */
+  public function down(): void
+  {
+    if (DB::connection()->getDriverName() === 'pgsql') {
+      DB::statement('DROP INDEX CONCURRENTLY IF EXISTS traffic_logs_s10_index');
+
+      return;
+    }
+
+    Schema::table('traffic_logs', function (Blueprint $table) {
+      $table->dropIndex(['s10']);
+    });
+  }
+};

--- a/resources/js/pages/ping-post/dispatches/index.tsx
+++ b/resources/js/pages/ping-post/dispatches/index.tsx
@@ -105,7 +105,7 @@ const DispatchesIndex = ({ rows, state, meta, data, dispatches_with_executions, 
           globalFilter={table.globalFilter}
           setGlobalFilter={table.setGlobalFilter}
           toolbarConfig={{
-            searchPlaceholder: 'Search fingerprint, UUID, UTM...',
+            searchPlaceholder: 'Search fingerprint, UUID, UTM, Click ID...',
             filters: [
               {
                 columnId: 'workflow_id',

--- a/tests/Feature/Logs/DispatchLogS10SearchTest.php
+++ b/tests/Feature/Logs/DispatchLogS10SearchTest.php
@@ -1,0 +1,81 @@
+<?php
+
+use App\Enums\DispatchStatus;
+use App\Models\Lead;
+use App\Models\LeadDispatch;
+use App\Models\TrafficLog;
+use App\Models\User;
+use App\Models\Workflow;
+use Inertia\Testing\AssertableInertia;
+
+use function Pest\Laravel\actingAs;
+
+/**
+ * Seed two dispatches with distinct fingerprints, each backed by a traffic_log
+ * carrying a distinct s10 (tracking platform click id). Returns both dispatches.
+ *
+ * @return array{a: LeadDispatch, b: LeadDispatch}
+ */
+function seedS10Scenario(): array
+{
+  $workflow = Workflow::factory()->bestBid()->create();
+
+  $leadA = Lead::factory()->create(['fingerprint' => 'fp-s10-a-' . uniqid()]);
+  $leadB = Lead::factory()->create(['fingerprint' => 'fp-s10-b-' . uniqid()]);
+
+  $a = LeadDispatch::create([
+    'workflow_id' => $workflow->id,
+    'lead_id' => $leadA->id,
+    'fingerprint' => $leadA->fingerprint,
+    'status' => DispatchStatus::SOLD,
+    'strategy_used' => $workflow->strategy?->value,
+    'started_at' => now(),
+  ]);
+
+  $b = LeadDispatch::create([
+    'workflow_id' => $workflow->id,
+    'lead_id' => $leadB->id,
+    'fingerprint' => $leadB->fingerprint,
+    'status' => DispatchStatus::NOT_SOLD,
+    'strategy_used' => $workflow->strategy?->value,
+    'started_at' => now(),
+  ]);
+
+  TrafficLog::factory()->create(['fingerprint' => $leadA->fingerprint, 's10' => 'CLICK-AAA-111']);
+  TrafficLog::factory()->create(['fingerprint' => $leadB->fingerprint, 's10' => 'CLICK-BBB-222']);
+
+  return ['a' => $a, 'b' => $b];
+}
+
+beforeEach(function () {
+  $this->admin = User::factory()->create(['role' => 'admin']);
+});
+
+test('global search by s10 returns only the matching dispatch', function () {
+  ['a' => $a] = seedS10Scenario();
+
+  $response = actingAs($this->admin)->get(route('ping-post.dispatches.index', ['search' => 'CLICK-AAA-111']));
+
+  $response->assertSuccessful();
+  $response->assertInertia(
+    fn(AssertableInertia $page) => $page->component('ping-post/dispatches/index')->has('rows.data', 1)->where('rows.data.0.id', $a->id),
+  );
+});
+
+test('global search by an unknown s10 returns no dispatches', function () {
+  seedS10Scenario();
+
+  $response = actingAs($this->admin)->get(route('ping-post.dispatches.index', ['search' => 'CLICK-NOPE-999']));
+
+  $response->assertSuccessful();
+  $response->assertInertia(fn(AssertableInertia $page) => $page->has('rows.data', 0));
+});
+
+test('global search still matches by fingerprint', function () {
+  ['b' => $b] = seedS10Scenario();
+
+  $response = actingAs($this->admin)->get(route('ping-post.dispatches.index', ['search' => $b->fingerprint]));
+
+  $response->assertSuccessful();
+  $response->assertInertia(fn(AssertableInertia $page) => $page->has('rows.data', 1)->where('rows.data.0.id', $b->id));
+});


### PR DESCRIPTION
Enhances the LeadDispatchLogController to support global search functionality that includes matching against the `s10` field in the `traffic_logs` table. Introduces a new method, applyDispatchSearch, to facilitate this search across multiple columns. Additionally, adds a migration to create an index on the `s10` column for improved query performance. Updates the frontend to reflect the new search capabilities and includes tests to validate the search functionality for both known and unknown click IDs.