### PR TITLE
feat: add route parameters support to useServerTable hook for dynamic routing

### DIFF
--- a/resources/js/hooks/use-server-table.tsx
+++ b/resources/js/hooks/use-server-table.tsx
@@ -8,6 +8,11 @@ interface ServerTableOptions {
   initialState: any;
   defaultPageSize?: number;
   includeInReload?: string[];
+  /**
+   * Route parameters for parameterized routes (e.g. `landing_pages.leads` needs `{ landing_page: id }`).
+   * Default `undefined` works for unparameterized routes.
+   */
+  routeParams?: Record<string, any> | any[];
 }
 
 interface ServerTableState {
@@ -24,7 +29,13 @@ interface ServerTableState {
   resetPagination: () => void;
 }
 
-export function useServerTable({ routeName, initialState, defaultPageSize = 10, includeInReload = [] }: ServerTableOptions): ServerTableState {
+export function useServerTable({
+  routeName,
+  initialState,
+  defaultPageSize = 10,
+  includeInReload = [],
+  routeParams,
+}: ServerTableOptions): ServerTableState {
   const isFirstRender = useRef(true);
 
   // Estado inicial
@@ -72,7 +83,7 @@ export function useServerTable({ routeName, initialState, defaultPageSize = 10, 
       onFinish: () => setIsLoading(false),
     };
 
-    router.get(route(routeName), payload, options);
+    router.get(route(routeName, routeParams), payload, options);
   };
 
   // Efecto principal: cuando cambian filtros o sorting, resetear página y fetch

--- a/resources/js/pages/landings/leads.tsx
+++ b/resources/js/pages/landings/leads.tsx
@@ -87,6 +87,7 @@ const Leads = ({ rows, meta, state, data }: LeadsPageProps) => {
 
   const table = useServerTable({
     routeName: 'landing_pages.leads',
+    routeParams: { landing_page: landing_page.id },
     initialState: state,
     defaultPageSize: 25,
   });


### PR DESCRIPTION
Enhances the useServerTable hook by introducing routeParams, allowing for parameterized routes in server-side data fetching. Updates the Leads page to utilize this new feature, enabling dynamic routing based on landing page IDs. This change improves flexibility in handling various landing page contexts.