### PR TITLE
feat: enhance landing page leads with traffic log integration and filtering options

### DIFF
--- a/app/Http/Controllers/LandingPageLeadsController.php
+++ b/app/Http/Controllers/LandingPageLeadsController.php
@@ -8,8 +8,10 @@ use App\Models\LandingPageColumn;
 use App\Models\Lead;
 use App\Models\TrafficLog;
 use App\Traits\DatatableTrait;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\DB;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -18,12 +20,82 @@ class LandingPageLeadsController extends Controller
   use DatatableTrait;
 
   /**
+   * Traffic columns surfaced via the `latest_tl` join (see applyLatestTrafficLogJoin).
+   * Listed here once and consumed by:
+   *   - the JOIN's projected SELECT aliases (`latest_<col>`)
+   *   - `allowedSort` so the toolbar can sort by any of them
+   * Keep the list narrow — every column added here travels in every request.
+   */
+  private const SORTABLE_TRAFFIC_COLUMNS = ['browser', 'os', 'device_type', 'state', 'city', 'postal_code', 'ip_address', 'referrer'];
+
+  /** Static US states catalog used by the State filter. */
+  private const US_STATES = [
+    'AL',
+    'AK',
+    'AZ',
+    'AR',
+    'CA',
+    'CO',
+    'CT',
+    'DE',
+    'FL',
+    'GA',
+    'HI',
+    'ID',
+    'IL',
+    'IN',
+    'IA',
+    'KS',
+    'KY',
+    'LA',
+    'ME',
+    'MD',
+    'MA',
+    'MI',
+    'MN',
+    'MS',
+    'MO',
+    'MT',
+    'NE',
+    'NV',
+    'NH',
+    'NJ',
+    'NM',
+    'NY',
+    'NC',
+    'ND',
+    'OH',
+    'OK',
+    'OR',
+    'PA',
+    'RI',
+    'SC',
+    'SD',
+    'TN',
+    'TX',
+    'UT',
+    'VT',
+    'VA',
+    'WA',
+    'WV',
+    'WI',
+    'WY',
+    'DC',
+  ];
+
+  /** Device type values produced by `DeviceDetectionService` (mobile|desktop). */
+  private const DEVICE_TYPE_OPTIONS = ['mobile', 'desktop'];
+
+  /** Common OS values; matched with LIKE so variants like "Windows NT 10.0" still match "Windows". */
+  private const OS_OPTIONS = ['Windows', 'Mac', 'iOS', 'Android', 'Linux'];
+
+  /**
    * Baseline column set surfaced when a landing has no `landing_page_columns` configured.
    *
    * @var array<int, array{key: string, label: string, source: string, reference: string}>
    */
   private const BASELINE_DESCRIPTORS = [
-    ['key' => 'meta:id', 'label' => 'ID', 'source' => 'meta', 'reference' => 'id'],
+    ['key' => 'meta:fingerprint', 'label' => 'Fingerprint', 'source' => 'meta', 'reference' => 'fingerprint'],
     ['key' => 'meta:created_at', 'label' => 'Created At', 'source' => 'meta', 'reference' => 'created_at'],
     ['key' => 'traffic:postal_code', 'label' => 'Geo Postal Code', 'source' => 'traffic', 'reference' => 'postal_code'],
     ['key' => 'traffic:ip_address', 'label' => 'Geo IP Address', 'source' => 'traffic', 'reference' => 'ip_address'],
@@ -63,13 +135,22 @@ class LandingPageLeadsController extends Controller
       ->select('fingerprint');
 
     $query = Lead::query()
-      ->whereIn('fingerprint', $fingerprintSubquery)
+      ->select('leads.*')
+      ->whereIn('leads.fingerprint', $fingerprintSubquery)
       ->with(['leadFieldResponses.field', 'latestTrafficLog.landingPageVersion']);
+
+    // Join the latest traffic_log row per lead as `latest_tl` so its columns are
+    // first-class joined fields, usable in WHERE / ORDER BY / SELECT in a single
+    // query trip per lead. Strategy is driver-aware (LATERAL on Postgres,
+    // portable id-subquery elsewhere). See applyLatestTrafficLogJoin().
+    $this->applyLatestTrafficLogJoin($query);
 
     // Default page size for this viewer is 25 (DatatableTrait default is 10).
     if (!$request->has('per_page')) {
       $request->merge(['per_page' => 25]);
     }
+
+    $sortableLatestColumns = collect(self::SORTABLE_TRAFFIC_COLUMNS)->map(fn($c) => 'latest_' . $c)->all();
 
     $table = $this->processDatatableQuery(
       query: $query,
@@ -78,8 +159,12 @@ class LandingPageLeadsController extends Controller
       filterConfig: [
         'from_date' => ['type' => 'from_date', 'column' => 'leads.created_at'],
         'to_date' => ['type' => 'to_date', 'column' => 'leads.created_at'],
+        // Filters now reference real joined columns — DatatableTrait handles them natively.
+        'device_type' => ['type' => 'exact', 'column' => 'latest_tl.device_type'],
+        'state' => ['type' => 'exact', 'column' => 'latest_tl.state'],
+        'os' => ['type' => 'like', 'column' => 'latest_tl.os'],
       ],
-      allowedSort: ['id', 'created_at'],
+      allowedSort: array_merge(['id', 'created_at'], $sortableLatestColumns),
       defaultSort: 'created_at:desc',
     );
 
@@ -95,6 +180,11 @@ class LandingPageLeadsController extends Controller
         'versions' => $versions,
         'selected_versions' => $selectedVersions,
         'using_defaults' => $usingDefaults,
+        'filter_options' => [
+          'device_type' => array_map(fn($v) => ['value' => $v, 'label' => ucfirst($v)], self::DEVICE_TYPE_OPTIONS),
+          'state' => array_map(fn($v) => ['value' => $v, 'label' => $v], self::US_STATES),
+          'os' => array_map(fn($v) => ['value' => $v, 'label' => $v], self::OS_OPTIONS),
+        ],
       ],
     ]);
   }
@@ -155,6 +245,7 @@ class LandingPageLeadsController extends Controller
 
     return [
       'id' => $lead->id,
+      'fingerprint' => $lead->fingerprint,
       'created_at' => $lead->created_at?->toIso8601String(),
       'version' => $version ? ['id' => $version->id, 'path' => $version->path] : null,
       'values' => $values,
@@ -180,5 +271,53 @@ class LandingPageLeadsController extends Controller
       return $lead->created_at?->toIso8601String();
     }
     return $lead->{$reference};
+  }
+
+  /**
+   * Join the most recent traffic_log per lead as `latest_tl`, exposing
+   * `latest_tl.<col>` (real joined columns, usable in WHERE/ORDER BY) plus
+   * `latest_<col>` SELECT aliases used by the frontend sort keys.
+   *
+   * Strategy is driver-aware:
+   *   - PostgreSQL: `LEFT JOIN LATERAL (...) ON TRUE` — the lateral subquery
+   *     can reference outer `leads.fingerprint` and only runs ONCE per lead,
+   *     returning all needed columns in a single trip.
+   *   - Other drivers (SQLite for tests): one correlated subquery picks the
+   *     latest traffic_log id per lead, then a regular JOIN materializes
+   *     that row's columns. Same shape, portable, still single-trip per lead.
+   */
+  private function applyLatestTrafficLogJoin(Builder $query): void
+  {
+    $driver = DB::connection()->getDriverName();
+    $cols = self::SORTABLE_TRAFFIC_COLUMNS;
+
+    if ($driver === 'pgsql') {
+      $colList = implode(', ', $cols);
+      // ON TRUE is intentional — the actual correlation lives inside the
+      // LATERAL subquery via `WHERE traffic_logs.fingerprint = leads.fingerprint`.
+      $query->leftJoin(
+        DB::raw(
+          "LATERAL (SELECT {$colList} FROM traffic_logs WHERE traffic_logs.fingerprint = leads.fingerprint ORDER BY created_at DESC LIMIT 1) AS latest_tl",
+        ),
+        DB::raw('1'),
+        '=',
+        DB::raw('1'),
+      );
+    } else {
+      // Portable: pick the latest id once per lead, then JOIN the full row.
+      $query->leftJoin('traffic_logs as latest_tl', function ($join) {
+        $join->on(
+          'latest_tl.id',
+          '=',
+          DB::raw('(SELECT id FROM traffic_logs t WHERE t.fingerprint = leads.fingerprint ORDER BY t.created_at DESC LIMIT 1)'),
+        );
+      });
+    }
+
+    // SELECT aliases so the frontend column ids (latest_device_type, ...)
+    // map cleanly onto allowedSort targets.
+    foreach ($cols as $col) {
+      $query->addSelect(DB::raw("latest_tl.{$col} AS latest_{$col}"));
+    }
   }
 }

--- a/resources/js/pages/landings/leads.tsx
+++ b/resources/js/pages/landings/leads.tsx
@@ -1,5 +1,6 @@
 import { DataTableColumnHeader } from '@/components/data-table/column-header';
 import { ServerTable } from '@/components/data-table/server-table';
+import { FormattedDateTime } from '@/components/formatted-date-time';
 import PageHeader from '@/components/page-header';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
@@ -8,8 +9,8 @@ import { useServerTable } from '@/hooks/use-server-table';
 import AppLayout from '@/layouts/app-layout';
 import { type BreadcrumbItem, type DatatablePageProps } from '@/types';
 import type { ColumnDescriptor, LeadRow, LeadsViewerData } from '@/types/models/landing-page-leads';
-import { Head, Link } from '@inertiajs/react';
-import { Info, SquareArrowOutUpRight } from 'lucide-react';
+import { Head } from '@inertiajs/react';
+import { Info, Monitor, Smartphone, SquareArrowOutUpRight } from 'lucide-react';
 import { useMemo, type ReactNode } from 'react';
 import { route } from 'ziggy-js';
 
@@ -17,61 +18,95 @@ interface LeadsPageProps extends DatatablePageProps<LeadRow> {
   data: LeadsViewerData;
 }
 
-function buildLeadColumns(descriptors: ColumnDescriptor[]) {
-  const cols: any[] = [
-    {
-      accessorKey: 'created_at',
-      header: ({ column }: any) => <DataTableColumnHeader column={column} title="Created At" />,
-      cell: ({ row }: any) => {
-        const value = row.original.created_at;
-        if (!value) return <span className="text-muted-foreground">—</span>;
-        return <span className="text-sm">{new Date(value).toLocaleString()}</span>;
-      },
-      enableSorting: true,
-    },
-    {
-      id: 'version',
-      header: 'Version',
-      cell: ({ row }: any) => {
-        const version = row.original.version;
-        if (!version) {
-          return <span className="text-muted-foreground">—</span>;
-        }
-        return (
-          <Badge variant="secondary" className="font-mono text-xs">
-            {version.path}
-          </Badge>
-        );
-      },
-      enableSorting: false,
-    },
-  ];
+const DEVICE_ICONS: Record<string, { icon: typeof Monitor; className: string; label: string }> = {
+  mobile: { icon: Smartphone, className: 'text-emerald-500', label: 'Mobile' },
+  desktop: { icon: Monitor, className: 'text-sky-500', label: 'Desktop' },
+};
 
-  for (const descriptor of descriptors) {
-    if (descriptor.source === 'meta' && descriptor.reference === 'id') {
-      cols.unshift({
-        accessorKey: 'id',
-        header: ({ column }: any) => <DataTableColumnHeader column={column} title="ID" />,
-        cell: ({ row }: any) => <span className="text-sm font-medium">{row.original.id}</span>,
-        enableSorting: true,
-      });
-      continue;
-    }
-    if (descriptor.source === 'meta' && descriptor.reference === 'created_at') {
-      continue;
-    }
+function DeviceTypeCell({ value }: { value: string | null }) {
+  if (!value) return <span className="text-muted-foreground">—</span>;
+  const config = DEVICE_ICONS[value.toLowerCase()];
+  if (!config) {
+    return <span className="text-sm capitalize">{value}</span>;
+  }
+  const Icon = config.icon;
+  return (
+    <span className="flex items-center gap-1.5" title={config.label}>
+      <Icon className={`h-4 w-4 ${config.className}`} />
+      <span className="text-sm">{config.label}</span>
+    </span>
+  );
+}
+
+function trafficColumnId(reference: string) {
+  return 'latest_' + reference;
+}
+
+function buildLeadColumns(descriptors: ColumnDescriptor[]) {
+  const fingerprintDescriptor = descriptors.find((d) => d.source === 'meta' && d.reference === 'fingerprint');
+  const createdAtDescriptor = descriptors.find((d) => d.source === 'meta' && d.reference === 'created_at');
+  const dataDescriptors = descriptors.filter((d) => d.source !== 'meta');
+
+  const cols: any[] = [];
+
+  if (fingerprintDescriptor) {
+    cols.push({
+      id: 'fingerprint',
+      accessorKey: 'fingerprint',
+      header: 'Fingerprint',
+      cell: ({ row }: any) => (
+        // CSS-only truncation: the full string stays in the DOM so the user can
+        // select + copy it; the ellipsis is purely visual.
+        <span className="block max-w-[150px] truncate font-mono text-xs" title={row.original.fingerprint}>
+          {row.original.fingerprint}
+        </span>
+      ),
+      enableSorting: false,
+    });
+  }
+
+  for (const descriptor of dataDescriptors) {
+    const isTraffic = descriptor.source === 'traffic';
+    const columnId = isTraffic ? trafficColumnId(descriptor.reference) : descriptor.key;
+    const isDeviceType = isTraffic && descriptor.reference === 'device_type';
 
     cols.push({
-      id: descriptor.key,
-      header: descriptor.label,
+      id: columnId,
+      header: ({ column }: any) => <DataTableColumnHeader column={column} title={descriptor.label} />,
       cell: ({ row }: any) => {
         const value = row.original.values?.[descriptor.key];
+        if (isDeviceType) return <DeviceTypeCell value={value} />;
         if (value === null || value === undefined || value === '') {
           return <span className="text-muted-foreground">—</span>;
         }
         return <span className="text-sm">{String(value)}</span>;
       },
-      enableSorting: false,
+      enableSorting: isTraffic, // field-source columns aren't projected as virtual cols, so they stay non-sortable
+    });
+  }
+
+  cols.push({
+    id: 'version',
+    header: 'Version',
+    cell: ({ row }: any) => {
+      const version = row.original.version;
+      if (!version) return <span className="text-muted-foreground">—</span>;
+      return (
+        <Badge variant="secondary" className="font-mono text-xs">
+          {version.path}
+        </Badge>
+      );
+    },
+    enableSorting: false,
+  });
+
+  if (createdAtDescriptor) {
+    cols.push({
+      id: 'created_at',
+      accessorKey: 'created_at',
+      header: ({ column }: any) => <DataTableColumnHeader column={column} title="Created At" />,
+      cell: ({ row }: any) => <FormattedDateTime date={row.original.created_at} />,
+      enableSorting: true,
     });
   }
 
@@ -79,7 +114,7 @@ function buildLeadColumns(descriptors: ColumnDescriptor[]) {
 }
 
 const Leads = ({ rows, meta, state, data }: LeadsPageProps) => {
-  const { landing_page, descriptors, versions, using_defaults } = data;
+  const { landing_page, descriptors, versions, using_defaults, filter_options } = data;
 
   const columns = useMemo(() => buildLeadColumns(descriptors), [descriptors]);
 
@@ -98,19 +133,23 @@ const Leads = ({ rows, meta, state, data }: LeadsPageProps) => {
     { title: 'Leads', href: '#' },
   ];
 
+  const toolbarFilters = [
+    ...(versionOptions.length > 0 ? [{ columnId: 'version', title: 'Version', options: versionOptions }] : []),
+    { columnId: 'device_type', title: 'Device', options: filter_options.device_type },
+    { columnId: 'state', title: 'State', options: filter_options.state },
+    { columnId: 'os', title: 'OS', options: filter_options.os },
+  ];
+
   return (
     <AppLayout breadcrumbs={breadcrumbs}>
       <Head title={`Leads — ${landing_page.name}`} />
       <div className="slide-in-up relative flex-1 space-y-6 p-6 md:p-8">
         <PageHeader title={`${landing_page.name} — Leads`} description={landing_page.url}>
-          <Button variant="outline" size="sm" asChild>
+          <Button asChild>
             <a href={landing_page.url} target="_blank" rel="noopener noreferrer" className="flex items-center gap-2">
               Visit landing
               <SquareArrowOutUpRight className="h-4 w-4" />
             </a>
-          </Button>
-          <Button variant="ghost" size="sm" asChild>
-            <Link href={route('landing_pages.index')}>Back</Link>
           </Button>
         </PageHeader>
 
@@ -140,16 +179,7 @@ const Leads = ({ rows, meta, state, data }: LeadsPageProps) => {
           setGlobalFilter={table.setGlobalFilter}
           toolbarConfig={{
             searchPlaceholder: 'Search…',
-            filters:
-              versionOptions.length > 0
-                ? [
-                    {
-                      columnId: 'version',
-                      title: 'Version',
-                      options: versionOptions,
-                    },
-                  ]
-                : [],
+            filters: toolbarFilters,
             dateRange: { column: 'created_at', label: 'Created At' },
           }}
         />

--- a/resources/js/types/models/landing-page-leads.ts
+++ b/resources/js/types/models/landing-page-leads.ts
@@ -15,9 +15,21 @@ export interface LandingPageVersionRef {
 
 export interface LeadRow {
   id: number;
+  fingerprint: string;
   created_at: string | null;
   version: LandingPageVersionRef | null;
   values: Record<string, string | null>;
+}
+
+export interface FilterOption {
+  value: string;
+  label: string;
+}
+
+export interface FilterOptionsCatalog {
+  device_type: FilterOption[];
+  state: FilterOption[];
+  os: FilterOption[];
 }
 
 export interface LeadsViewerData {
@@ -26,4 +38,5 @@ export interface LeadsViewerData {
   versions: LandingPageVersionRef[];
   selected_versions: number[];
   using_defaults: boolean;
+  filter_options: FilterOptionsCatalog;
 }

--- a/tests/Feature/LandingPages/LeadsViewerTest.php
+++ b/tests/Feature/LandingPages/LeadsViewerTest.php
@@ -50,7 +50,7 @@ it('returns baseline descriptors when the landing has no columns configured', fu
 
   $byKey = collect($data['descriptors'])->keyBy('key');
   expect($byKey)->toHaveKeys([
-    'meta:id',
+    'meta:fingerprint',
     'meta:created_at',
     'traffic:postal_code',
     'traffic:ip_address',
@@ -177,6 +177,39 @@ it('filters leads by version when the version filter is set', function () {
   $props = $response->viewData('page')['props'];
   expect($props['meta']['total'])->toBe(2);
   expect($props['data']['selected_versions'])->toBe([$versionA->id]);
+});
+
+it('filters leads by device_type, state and os using latest traffic columns', function () {
+  $landingPage = LandingPage::factory()->create();
+
+  $desktopUS = attachLeadToLanding($landingPage, null, ['device_type' => 'desktop', 'state' => 'CA', 'os' => 'Windows NT 10.0']);
+  $mobileUS = attachLeadToLanding($landingPage, null, ['device_type' => 'mobile', 'state' => 'CA', 'os' => 'iOS 17.5']);
+  $desktopOther = attachLeadToLanding($landingPage, null, ['device_type' => 'desktop', 'state' => 'NY', 'os' => 'Linux']);
+
+  $filtersJson = json_encode([['id' => 'device_type', 'value' => ['desktop']]]);
+  $response = actingAs($this->user)->get(route('landing_pages.leads', $landingPage->id) . '?filters=' . urlencode($filtersJson));
+  expect($response->viewData('page')['props']['meta']['total'])->toBe(2);
+
+  $filtersJson = json_encode([['id' => 'state', 'value' => ['CA']]]);
+  $response = actingAs($this->user)->get(route('landing_pages.leads', $landingPage->id) . '?filters=' . urlencode($filtersJson));
+  expect($response->viewData('page')['props']['meta']['total'])->toBe(2);
+
+  // OS uses LIKE matching so "Windows" matches "Windows NT 10.0".
+  $filtersJson = json_encode([['id' => 'os', 'value' => ['Windows']]]);
+  $response = actingAs($this->user)->get(route('landing_pages.leads', $landingPage->id) . '?filters=' . urlencode($filtersJson));
+  $rows = $response->viewData('page')['props']['rows']['data'];
+  expect(collect($rows)->pluck('id')->all())->toBe([$desktopUS->id]);
+});
+
+it('exposes static filter_options catalogs to the frontend', function () {
+  $landingPage = LandingPage::factory()->create();
+
+  $response = actingAs($this->user)->get(route('landing_pages.leads', $landingPage->id));
+  $options = $response->viewData('page')['props']['data']['filter_options'];
+
+  expect(collect($options['device_type'])->pluck('value')->all())->toEqualCanonicalizing(['mobile', 'desktop']);
+  expect(collect($options['state'])->pluck('value')->all())->toContain('CA', 'NY', 'TX');
+  expect(collect($options['os'])->pluck('value')->all())->toEqualCanonicalizing(['Windows', 'Mac', 'iOS', 'Android', 'Linux']);
 });
 
 it('paginates with a default size of 25 sorted by created_at desc', function () {


### PR DESCRIPTION
Implements a new traffic log join in the LandingPageLeadsController to expose latest traffic data for leads, allowing for advanced filtering by device type, state, and operating system. Updates the frontend to display these new filter options and integrates them into the leads data table. Additionally, modifies the data structure to include fingerprint and filter options in the LeadsViewerData interface, ensuring a comprehensive view of lead information. Enhances tests to validate the new filtering capabilities and data exposure.