### PR TITLE
feat: add accessor function for sortable columns in leads data table

### DIFF
--- a/resources/js/pages/landings/leads.tsx
+++ b/resources/js/pages/landings/leads.tsx
@@ -72,6 +72,10 @@ function buildLeadColumns(descriptors: ColumnDescriptor[]) {
 
     cols.push({
       id: columnId,
+      // accessorFn is required for `column.getCanSort()` to return true — TanStack
+      // refuses to mark a column as sortable when it has no accessor, even if
+      // enableSorting is true. The value lives nested in `row.values[key]`.
+      accessorFn: (row: LeadRow) => row.values?.[descriptor.key] ?? null,
       header: ({ column }: any) => <DataTableColumnHeader column={column} title={descriptor.label} />,
       cell: ({ row }: any) => {
         const value = row.original.values?.[descriptor.key];


### PR DESCRIPTION
Implements an accessor function in the leads data table to ensure columns are sortable, addressing a limitation in TanStack's column sorting behavior. This change enhances the user experience by allowing for proper sorting of lead data based on specified descriptors.