### PR TITLE
feat: sanitize UUID input in postback URL generation

### DIFF
--- a/resources/js/catalyst/v1.0.ts
+++ b/resources/js/catalyst/v1.0.ts
@@ -989,8 +989,14 @@ class CatalystCore {
       throw new Error(`Catalyst SDK: ${error}`);
     }
 
+    // Defensive: strip accidental wrapping quotes/whitespace from the uuid.
+    // A landing may pass a JSON-encoded value (e.g. `"<uuid>"`), which would
+    // otherwise reach the URL as `%22<uuid>` and fail the backend route
+    // constraint `[0-9a-f-]{36}` with a 404 "route could not be found".
+    const cleanUuid = uuid.trim().replace(/^["']+|["']+$/g, '');
+
     const base = this.getEndpoint('POSTBACK.FIRE_INTERNAL');
-    let url = `${base}${uuid}/${encodeURIComponent(resolvedFingerprint)}/${encodeURIComponent(source)}`;
+    let url = `${base}${encodeURIComponent(cleanUuid)}/${encodeURIComponent(resolvedFingerprint)}/${encodeURIComponent(source)}`;
 
     const query = new URLSearchParams();
     for (const [key, value] of Object.entries(fields)) {


### PR DESCRIPTION
Implements a defensive measure to clean UUID inputs by stripping accidental wrapping quotes and whitespace before constructing the postback URL. This change prevents potential 404 errors caused by improperly formatted UUIDs, enhancing the robustness of the URL generation process in the Catalyst SDK.