### PR TITLE
feat: implement buildFieldValueMaps method for original and mapped values

### DIFF
--- a/app/Services/Offerwall/ConversionService.php
+++ b/app/Services/Offerwall/ConversionService.php
@@ -92,7 +92,14 @@ class ConversionService
       // If we got here, we have a valid integration
       $integrationId = $integration->id;
 
-      // Extract tracked fields from the log's context arrays
+      // Extract tracked fields from the log's context arrays.
+      // NOTE (intentional mapping — do not "fix"): the original/mapped asymmetry is
+      // deliberate. `placement_id` is read from the MAPPED value of `cptype` on
+      // purpose (placement is derived from cptype's value_mapping), while `cptype`
+      // itself keeps its ORIGINAL (pre-mapping) value. Likewise `state` is original
+      // and `zip_code` is mapped. These arrays are populated upstream by
+      // MixService::logIntegrationCall via PayloadProcessorService::buildFieldValueMaps,
+      // keyed by field name. If they ever come back null, check that wiring first.
       $trackedFields = [
         'cptype' => $callLog->original_field_values['cptype'] ?? null,
         'placement_id' => $callLog->mapped_field_values['cptype'] ?? null,

--- a/app/Services/Offerwall/MixService.php
+++ b/app/Services/Offerwall/MixService.php
@@ -71,6 +71,7 @@ class MixService
           }
           $processor = new \App\Services\PayloadProcessorService();
           $replacements = $processor->buildReplacements($integration, $prodEnv, $leadData);
+          $fieldValueMaps = $processor->buildFieldValueMaps($integration, $prodEnv, $leadData);
 
           $payloadString = $processor->applyReplacements($prodEnv->request_body ?? '{}', $replacements);
           $payload = json_decode($payloadString, true) ?? [];
@@ -94,6 +95,8 @@ class MixService
             'payload' => $payload,
             'method' => $method,
             'headers' => $headers,
+            'originalValues' => $fieldValueMaps['originalValues'],
+            'mappedValues' => $fieldValueMaps['mappedValues'],
           ];
         }
 
@@ -118,7 +121,16 @@ class MixService
           $response = $responses[$integration->id];
           $requestData = $requestsData[$integration->id];
 
-          $this->logIntegrationCall($mixLog, $integration, $response, $requestData['method'], $requestData['headers'], $requestData['payload']);
+          $this->logIntegrationCall(
+            $mixLog,
+            $integration,
+            $response,
+            $requestData['method'],
+            $requestData['headers'],
+            $requestData['payload'],
+            $requestData['originalValues'],
+            $requestData['mappedValues'],
+          );
 
           if ($response instanceof Response && $response->successful()) {
             $successfulCount++;
@@ -230,8 +242,16 @@ class MixService
     return $lead->leadFieldResponses->pluck('value', 'field.name')->toArray();
   }
 
-  private function logIntegrationCall(OfferwallMixLog $mixLog, $integration, $response, string $method, array $headers, array $payload): void
-  {
+  private function logIntegrationCall(
+    OfferwallMixLog $mixLog,
+    $integration,
+    $response,
+    string $method,
+    array $headers,
+    array $payload,
+    ?array $originalValues = null,
+    ?array $mappedValues = null,
+  ): void {
     $isResponse = $response instanceof Response;
     $duration = $isResponse && $response->transferStats ? $response->transferStats->getTransferTime() * 1000 : 0;
 
@@ -265,8 +285,8 @@ class MixService
       'request_payload' => $payload,
       'response_headers' => $isResponse ? $response->headers() : [],
       'response_body' => $responseBody,
-      'original_field_values' => null,
-      'mapped_field_values' => null,
+      'original_field_values' => $originalValues,
+      'mapped_field_values' => $mappedValues,
     ]);
   }
 

--- a/app/Services/PayloadProcessorService.php
+++ b/app/Services/PayloadProcessorService.php
@@ -133,6 +133,43 @@ class PayloadProcessorService
   }
 
   /**
+   * Build the original/mapped value maps for all tokens, keyed by FIELD NAME.
+   *
+   * Sibling of buildReplacements() but without watermarking/hashing: returns the
+   * raw lead value (or default) and the value after value_mapping, so callers can
+   * persist tracking context (e.g. IntegrationCallLog.original_field_values /
+   * mapped_field_values). Keyed by field name (not token) to match the lookups
+   * done downstream in ConversionService.
+   *
+   * @param  Integration             $integration  With tokenMappings.field eager-loaded
+   * @param  IntegrationEnvironment  $environment  (unused here; kept for signature parity with buildReplacements)
+   * @param  array<string, mixed>    $leadData     Lead fields keyed by field name
+   * @return array{originalValues: array<string, mixed>, mappedValues: array<string, mixed>}
+   */
+  public function buildFieldValueMaps(Integration $integration, IntegrationEnvironment $environment, array $leadData): array
+  {
+    $originalValues = [];
+    $mappedValues = [];
+
+    foreach ($integration->tokenMappings as $mapping) {
+      if (!$mapping->field) {
+        continue;
+      }
+
+      $name = $mapping->field->name;
+      $raw = $leadData[$name] ?? ($mapping->default_value ?? null);
+
+      $originalValues[$name] = $raw;
+      $mappedValues[$name] = $mapping->value_mapping[$raw] ?? $raw;
+    }
+
+    return [
+      'originalValues' => $originalValues,
+      'mappedValues' => $mappedValues,
+    ];
+  }
+
+  /**
    * Apply a precomputed replacement map to a template and release type watermarks.
    *
    * @param  string                $template     Body, headers JSON, or URL string

--- a/tests/Feature/Offerwall/OfferwallTrackedFieldsTest.php
+++ b/tests/Feature/Offerwall/OfferwallTrackedFieldsTest.php
@@ -1,0 +1,170 @@
+<?php
+
+use App\Models\Field;
+use App\Models\Integration;
+use App\Models\Lead;
+use App\Models\OfferwallMix;
+use App\Models\User;
+use App\Services\Offerwall\MixService;
+use App\Services\PayloadProcessorService;
+use Illuminate\Support\Facades\Http;
+
+/**
+ * Regresion: el refactor cc1fdb7 dejo MixService::logIntegrationCall persistiendo
+ * original_field_values / mapped_field_values en null hardcodeado. Como
+ * ConversionService arma tracked_fields leyendo esas columnas, las offerwall
+ * conversions quedaban con todos los valores en null (keys presentes, values null).
+ *
+ * Estos tests cubren el fix: MixService vuelve a poblar ambos arrays via
+ * PayloadProcessorService::buildFieldValueMaps, y la conversion resultante recupera
+ * sus tracked_fields con valores reales.
+ */
+
+/**
+ * Crea integration offerwall + env de produccion con un parser config minimo
+ * y los tokenMappings/fields necesarios para los tracked_fields.
+ */
+function makeTrackedFieldsIntegration(): Integration
+{
+  $cptype = Field::factory()->create(['name' => 'cptype']);
+  $state = Field::factory()->create(['name' => 'state']);
+  $zip = Field::factory()->create(['name' => 'zip_code']);
+
+  $integration = Integration::factory()->create(['type' => 'offerwall', 'name' => 'Tracked Vendor']);
+  $env = $integration->environments()->create([
+    'env_type' => 'offerwall',
+    'environment' => 'production',
+    'url' => 'https://tracked-vendor.example.com/offers',
+    'method' => 'POST',
+    'request_headers' => '{}',
+    'request_body' => '{}',
+  ]);
+  $env->offerwallResponseConfig()->create([
+    'offer_list_path' => 'result',
+    'mapping' => [
+      'cpc' => 'rev',
+      'title' => 'title',
+      'company' => 'brand',
+    ],
+    'fallbacks' => null,
+  ]);
+
+  // cptype: original "web" -> mapped "PLACEMENT_99"
+  $integration->tokenMappings()->create([
+    'field_id' => $cptype->id,
+    'data_type' => 'string',
+    'default_value' => null,
+    'value_mapping' => ['web' => 'PLACEMENT_99'],
+  ]);
+  // state: sin value_mapping (original == mapped)
+  $integration->tokenMappings()->create([
+    'field_id' => $state->id,
+    'data_type' => 'string',
+    'default_value' => null,
+    'value_mapping' => null,
+  ]);
+  // zip_code: original "90001" -> mapped "ZIP_MAP"
+  $integration->tokenMappings()->create([
+    'field_id' => $zip->id,
+    'data_type' => 'string',
+    'default_value' => null,
+    'value_mapping' => ['90001' => 'ZIP_MAP'],
+  ]);
+
+  return $integration->load('tokenMappings.field', 'environments.fieldHashes');
+}
+
+function attachTrackedLeadResponses(Lead $lead, Integration $integration): void
+{
+  $byName = $integration->tokenMappings->keyBy(fn($m) => $m->field->name);
+  $values = ['cptype' => 'web', 'state' => 'CA', 'zip_code' => '90001'];
+  foreach ($values as $name => $value) {
+    $lead->leadFieldResponses()->create([
+      'field_id' => $byName[$name]->field_id,
+      'value' => $value,
+      'fingerprint' => $lead->fingerprint,
+    ]);
+  }
+}
+
+describe('Offerwall tracked_fields population', function () {
+  it('buildFieldValueMaps separates original and mapped values keyed by field name', function () {
+    $integration = makeTrackedFieldsIntegration();
+    $leadData = ['cptype' => 'web', 'state' => 'CA', 'zip_code' => '90001'];
+
+    $maps = (new PayloadProcessorService())->buildFieldValueMaps($integration, $integration->environments->first(), $leadData);
+
+    expect($maps['originalValues'])
+      ->toBe(['cptype' => 'web', 'state' => 'CA', 'zip_code' => '90001'])
+      ->and($maps['mappedValues'])
+      ->toBe(['cptype' => 'PLACEMENT_99', 'state' => 'CA', 'zip_code' => 'ZIP_MAP']);
+  });
+
+  it('MixService persists original/mapped field values on the IntegrationCallLog', function () {
+    $user = User::factory()->create();
+    $this->actingAs($user);
+
+    $integration = makeTrackedFieldsIntegration();
+    $lead = Lead::factory()->create(['fingerprint' => 'fp-tracked-fields']);
+    attachTrackedLeadResponses($lead, $integration);
+
+    $mix = OfferwallMix::create(['name' => 'Tracked Mix', 'is_active' => true]);
+    $mix->integrations()->attach($integration->id);
+
+    Http::fake([
+      'tracked-vendor.example.com/*' => Http::response(['result' => [['title' => 'Offer One', 'brand' => 'Acme', 'rev' => 1.0]]], 200),
+    ]);
+
+    app(MixService::class)->fetchAndAggregateOffers($mix->fresh(), $lead->fingerprint);
+
+    $callLog = \App\Models\IntegrationCallLog::where('integration_id', $integration->id)->latest('id')->first();
+
+    expect($callLog->original_field_values)
+      ->toBe(['cptype' => 'web', 'state' => 'CA', 'zip_code' => '90001'])
+      ->and($callLog->mapped_field_values)
+      ->toBe(['cptype' => 'PLACEMENT_99', 'state' => 'CA', 'zip_code' => 'ZIP_MAP']);
+  });
+
+  /**
+   * Cobertura del shape final de tracked_fields que arma ConversionService a partir
+   * de los arrays del call log. Se invoca el mismo mapeo deliberado de
+   * ConversionService::createConversion (cptype=original, placement_id=mapped[cptype],
+   * state=original, zip_code=mapped) sin pasar por el insert de offerwall_conversions,
+   * que en el test DB choca con la columna company_id NOT NULL (artefacto SQLite: la
+   * migration remove_company_id es no-op en sqlite, en produccion la columna no existe).
+   */
+  it('builds the intentional tracked_fields shape from a populated call log', function () {
+    $user = User::factory()->create();
+    $this->actingAs($user);
+
+    $integration = makeTrackedFieldsIntegration();
+    $lead = Lead::factory()->create(['fingerprint' => 'fp-tracked-shape']);
+    attachTrackedLeadResponses($lead, $integration);
+
+    $mix = OfferwallMix::create(['name' => 'Tracked Shape Mix', 'is_active' => true]);
+    $mix->integrations()->attach($integration->id);
+
+    Http::fake([
+      'tracked-vendor.example.com/*' => Http::response(['result' => [['title' => 'Offer One', 'brand' => 'Acme', 'rev' => 1.0]]], 200),
+    ]);
+
+    app(MixService::class)->fetchAndAggregateOffers($mix->fresh(), $lead->fingerprint);
+
+    $callLog = \App\Models\IntegrationCallLog::where('integration_id', $integration->id)->latest('id')->first();
+
+    // Espeja el mapeo de ConversionService::createConversion (intencional).
+    $trackedFields = [
+      'cptype' => $callLog->original_field_values['cptype'] ?? null,
+      'placement_id' => $callLog->mapped_field_values['cptype'] ?? null,
+      'state' => $callLog->original_field_values['state'] ?? null,
+      'zip_code' => $callLog->mapped_field_values['zip_code'] ?? null,
+    ];
+
+    expect($trackedFields)->toBe([
+      'cptype' => 'web', // original
+      'placement_id' => 'PLACEMENT_99', // mapped value of cptype (intentional)
+      'state' => 'CA', // original
+      'zip_code' => 'ZIP_MAP', // mapped
+    ]);
+  });
+});


### PR DESCRIPTION
Adds the buildFieldValueMaps method to the PayloadProcessorService, which constructs maps of original and mapped values for tokens based on integration configurations. This method enhances the ability to persist tracking context in IntegrationCallLog by providing structured access to field values. Additionally, updates MixService to utilize this new method, ensuring original and mapped values are correctly logged during integration calls. Introduces tests to validate the functionality and ensure accurate population of tracked fields.